### PR TITLE
fix: `ModuleTestingEnvironment` dependency

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -7,7 +7,7 @@
     "dependencies": [
         { "id": "CoreAssets", "minVersion": "2.0.0" },
         { "id": "Inventory", "minVersion": "1.1.0" },
-        { "id": "ModuleTestingEnvironment", "minVersion":"0.2.0" }
+        { "id": "ModuleTestingEnvironment", "minVersion":"0.2.0", "optional": true }
     ],
     "serverSideOnly": false,
     "isAsset": true,

--- a/module.txt
+++ b/module.txt
@@ -7,7 +7,7 @@
     "dependencies": [
         { "id": "CoreAssets", "minVersion": "2.0.0" },
         { "id": "Inventory", "minVersion": "1.1.0" },
-        { "id": "ModuleTestingEnvironment", "minVersion":"0.1.0" }
+        { "id": "ModuleTestingEnvironment", "minVersion":"0.2.0" }
     ],
     "serverSideOnly": false,
     "isAsset": true,


### PR DESCRIPTION
- pre-release minor versions seem to be treated like real-release major versions wrt inclusion/exclusion